### PR TITLE
Change andrewid check that occurs when adding to queue

### DIFF
--- a/app/routes/users.js
+++ b/app/routes/users.js
@@ -83,7 +83,7 @@ router.post('/adduser', function(req, res) {
     var db = req.db;
     var andrewId = req.body.andrewId;
 
-    if (students.indexOf(andrewId) < 0) {
+    if (students.indexOf(andrewId.toLowerCase()) < 0) {
         res.send({
             msg: "Your andrewID isn't associated with 15122!"
         });


### PR DESCRIPTION
...to be case insensitive. (Assuming that the andrewid list in studentIds.txt is all lower case)

Prompted by a student in office hours getting annoyed when they couldn't add themselves to the queue because they were capitalizing the first letter of their andrewid.
