### PR TITLE
fix bug where emailAlertSwitchLabel isn't synced with clicking the sw…

### DIFF
--- a/app/public/javascripts/admin.js
+++ b/app/public/javascripts/admin.js
@@ -10,8 +10,6 @@ $(document).ready(function() {
     $('#btnChangeName').on('click', btnSetName);
     $('#emailAlertSwitch').on('change', toggleEmails);
     $('#btnInputBulletin').on('click', btnSetBulletin);
-    $('#emailAlertSwitchLabel').html(on ? "On" : "Off");
-
 
     $('#inputQueueName').attr('placeholder', get_name());
     $('#inputBulletin').attr('placeholder', "New Bulletin");
@@ -60,11 +58,11 @@ function getEmailAlertSetting() {
         url: "/users/getEmailAlerts",
         dataType: 'JSON',
     }).done(function(response) {
-        on = response.msg;
-        $('#emailAlertSwitchLabel').html(on ? "On" : "Off");
-        if(on) {
-        $('#emailAlertCheck').attr('checked', "true");
-    }
+        emailAlerts = response.msg;
+        $('#emailAlertSwitchLabel').html(emailAlerts ? "On" : "Off");
+        if(emailAlerts) {
+            $('#emailAlertCheck').attr('checked', "true");
+        }
     });
 }
 

--- a/app/views/admin.jade
+++ b/app/views/admin.jade
@@ -20,7 +20,7 @@ block content
                                 h5 Email Alerts
                                 .switch#emailAlertSwitch
                                     label
-                                        span#emailAlertSwitchLabel On
+                                        span#emailAlertSwitchLabel Off
                                         input#emailAlertCheck(type="checkbox")
                                         span(class="lever tooltipped", data-position="right",data-delay="50",data-tooltip="Have the queue send emails on long queue times")
 


### PR DESCRIPTION
…itch

Currently, there's a bug in CMUQ. This PR fixes it. Well, at least it's a good deal better than before.

Steps to reproduce:
1. Login to CMUQ.
2. Go to Admin page.
3. Note that email alerts are on and the label says On. Click on it once, and note that it doesn't change.
4. Keep clicking and note how it's out of sync.

This commit makes email alerts off by default in the actual HTML but uses the immediate request that admin.js makes to set the switch to the correct value as given by the server. It also sets the local emailAlerts boolean to the appropriate value whenever the switch is pressed.
