### PR TITLE
fix bug with title disappearing on smaller screens

### DIFF
--- a/app/views/layout.jade
+++ b/app/views/layout.jade
@@ -13,7 +13,7 @@ html
 
   body
     nav.cyan
-        .col.s12
+        .col.s12.nav-wrapper
             #name
             ul#nav-mobile(class="right")
                 li


### PR DESCRIPTION
Steps to reproduce this bug:
- Go to https://cmuq.mod.bz/
- Watch the CMUQ logo in the top-left corner.
- Resize the window to half its width (I think the threshold is 992px or something like that).
- Wow, the logo disappears! Actually it's stuck in the middle of the webpage if you look hard enough, but since it's white letters, it's hard to find.

This seems to be due to a forgotten materialize class, so the change below is sufficient to fix this.
